### PR TITLE
example: add no loss lottery example and README

### DIFF
--- a/examples/no-loss-lottery/README.md
+++ b/examples/no-loss-lottery/README.md
@@ -12,6 +12,7 @@ that users cannot undelegate their funds at any time skewing the lottery results
 
 ### Deposits
 
+
 The contract uses its own balance as a pool of funds that users can deposit into. The contract
 then uses the `Staking` precompile to delegate the funds to a validator. This ensures that the funds
 are locked and cannot be undelegated from outside the contract. The contract keeps track of which user
@@ -19,10 +20,12 @@ delegated how much.
 
 ### Enter Lottery
 
+
 The contract allows users to enter the lottery by using the funds they have deposited into the contract
 to delegate to a validator.
 
 ### Draw Lottery
+
 
 The contract uses the `Distribution` precompile to calculate the rewards of the total pool of funds. Each user
 is assigned a number of tickets based on the amount of tokens they have delegated. Users are shuffled before each draw
@@ -30,10 +33,12 @@ and the winner is selected based on the number of tickets they have and a random
 
 ### Withdraw Winnings
 
+
 The contract keeps track of which user won each round and allows them to withdraw the winnings in a separate
 transaction called `withdrawWinnings`.
 
 ### Exit Lottery
+
 
 The contract allows users to exit the lottery by undelegating their funds from the validator. **NOTE** only
 the total amount delegated can be undelegated for simplicity. Once the 14 day unbonding period is over the
@@ -43,17 +48,20 @@ funds return to the contract and users can withdraw their funds using the `withd
 
 ### No Oracle randomness
 
+
 The contract does not use an oracle for its random number generator or `shuffleParticipants` function.
 This is fine for a showcase but be aware when deploying to testnet or mainnet you would need a verifiable
 source of randomness.
 
 ### Usage of `tx.origin` for Approvals
 
+
 This contract uses `tx.origin` for approvals to ensure only the user that deposited the funds can withdraw.
 This is limiting to only EOAs and not smart contracts. Ideally the contract would use `msg.sender` for approvals and
 allow smart contracts to interface with the contract.
 
 ### No Owner for the Contract
+
 
 The contract does not implement OpenZeppelin's `Ownable` contract. This can cause issues as anybody can
 execute the `pickWinner` function. Ideally some functions should be restricted to the owner of the contract
@@ -62,10 +70,12 @@ delegation rewards have been distributed
 
 ### No Multiple Validators
 
+
 The contract does not handle users delegating to multiple validators. This is for simplicity’s sake as this would require
 keeping track of which users have delegated to which validators and would require a more complex implementation.
 
 ### No Partial Exit Lottery
+
 
 The contract does not allow multiple undelegations with smaller amounts from the validator.
 This is for simplicity’s sake as this would require keeping track of which users have undelegated how much

--- a/examples/no-loss-lottery/README.md
+++ b/examples/no-loss-lottery/README.md
@@ -1,0 +1,62 @@
+# No Loss Lottery
+
+This is an example of how to create a smart contract for a no-loss-lottery that utilizes
+the `Staking` and `Distribution` precompiled contracts - [NoLossLottery](./contracts/NoLossLottery.sol)
+
+The contract showcases how you can use the contract itself as a manager of funds to ensure
+that users cannot undelegate their funds at any time skewing the lottery results.
+
+**THIS IS NOT A COPY / PASTE CONTRACT** as it has certain limitations and is generally not production ready.
+
+## Implementation
+
+### Deposits
+The contract uses its own balance as a pool of funds that users can deposit into. The contract
+then uses the `Staking` precompile to delegate the funds to a validator. This ensures that the funds
+are locked and cannot be undelegated from outside the contract. The contract keeps track of which user
+delegated how much.
+
+### Enter Lottery
+The contract allows users to enter the lottery by using the funds they have deposited into the contract
+to delegate to a validator.
+
+### Draw Lottery
+The contract uses the `Distribution` precompile to calculate the rewards of the total pool of funds. Each user
+is assigned a number of tickets based on the amount of tokens they have delegated. Users are shuffled before each draw
+and the winner is selected based on the number of tickets they have and a random number.
+
+### Withdraw Winnings
+The contract keeps track of which user won each round and allows them to withdraw the winnings in a separate
+transaction called `withdrawWinnings`.
+
+### Exit Lottery
+The contract allows users to exit the lottery by undelegating their funds from the validator. **NOTE** only 
+the total amount delegated can be undelegated for simplicity. Once the 14 day unbonding period is over the 
+funds return to the contract and users can withdraw their funds using the `withdraw` function.
+
+## Limitations
+
+### No Oracle randomness
+The contract does not use an oracle for its random number generator or `shuffleParticipants` function.
+This is fine for a showcase but be aware when deploying to testnet or mainnet you would need a verifiable
+source of randomness.
+
+### Usage of `tx.origin` for Approvals
+This contract uses `tx.origin` for approvals to ensure only the user that deposited the funds can withdraw.
+This is limiting to only EOAs and not smart contracts. Ideally the contract would use `msg.sender` for approvals and 
+allow smart contracts to interface with the contract.
+
+### No Owner for the Contract
+The contract does not implement OpenZeppelin's `Ownable` contract. This can cause issues as anybody can 
+execute the `pickWinner` function. Ideally some functions should be restricted to the owner of the contract
+like the `pickWinner` function which should be triggered off-chain a couple of seconds after the 
+delegation rewards have been distributed
+
+### No Multiple Validators
+The contract does not handle users delegating to multiple validators. This is for simplicity’s sake as this would require
+keeping track of which users have delegated to which validators and would require a more complex implementation.
+
+### No Partial Exit Lottery
+The contract does not allow multiple undelegations with smaller amounts from the validator. 
+This is for simplicity’s sake as this would require keeping track of which users have undelegated how much 
+and would require a more complex implementation.

--- a/examples/no-loss-lottery/README.md
+++ b/examples/no-loss-lottery/README.md
@@ -3,6 +3,12 @@
 This is an example of how to create a smart contract for a no-loss-lottery that utilizes
 the `Staking` and `Distribution` precompiled contracts - [NoLossLottery](./contracts/NoLossLottery.sol)
 
+A no-loss-lottery is a lottery where users deposit funds into a pool and delegate them to a validator. Once a day
+when the staking rewards are distributed, a random winner is picked from the pool of users based on their
+deposit amount (the higher deposit the better odds of winning the pool). The winner receives the total pot of rewards 
+for that day. The users that did not win the lottery can withdraw their funds at any time without losing any 
+of their initial deposit.
+
 The contract showcases how you can use the contract itself as a manager of funds to ensure
 that users cannot undelegate their funds at any time skewing the lottery results.
 
@@ -45,6 +51,12 @@ the total amount delegated can be undelegated for simplicity. Once the 14 day un
 funds return to the contract and users can withdraw their funds using the `withdraw` function.
 
 ## Limitations
+
+### No SafeMath 
+
+
+The contract does not use OpenZeppelin's `SafeMath` library. This is fine for a showcase but be aware when deploying
+to testnet or mainnet you would need to use `SafeMath` to prevent overflows.
 
 ### No Oracle randomness
 

--- a/examples/no-loss-lottery/README.md
+++ b/examples/no-loss-lottery/README.md
@@ -11,52 +11,62 @@ that users cannot undelegate their funds at any time skewing the lottery results
 ## Implementation
 
 ### Deposits
+
 The contract uses its own balance as a pool of funds that users can deposit into. The contract
 then uses the `Staking` precompile to delegate the funds to a validator. This ensures that the funds
 are locked and cannot be undelegated from outside the contract. The contract keeps track of which user
 delegated how much.
 
 ### Enter Lottery
+
 The contract allows users to enter the lottery by using the funds they have deposited into the contract
 to delegate to a validator.
 
 ### Draw Lottery
+
 The contract uses the `Distribution` precompile to calculate the rewards of the total pool of funds. Each user
 is assigned a number of tickets based on the amount of tokens they have delegated. Users are shuffled before each draw
 and the winner is selected based on the number of tickets they have and a random number.
 
 ### Withdraw Winnings
+
 The contract keeps track of which user won each round and allows them to withdraw the winnings in a separate
 transaction called `withdrawWinnings`.
 
 ### Exit Lottery
-The contract allows users to exit the lottery by undelegating their funds from the validator. **NOTE** only 
-the total amount delegated can be undelegated for simplicity. Once the 14 day unbonding period is over the 
+
+The contract allows users to exit the lottery by undelegating their funds from the validator. **NOTE** only
+the total amount delegated can be undelegated for simplicity. Once the 14 day unbonding period is over the
 funds return to the contract and users can withdraw their funds using the `withdraw` function.
 
 ## Limitations
 
 ### No Oracle randomness
+
 The contract does not use an oracle for its random number generator or `shuffleParticipants` function.
 This is fine for a showcase but be aware when deploying to testnet or mainnet you would need a verifiable
 source of randomness.
 
 ### Usage of `tx.origin` for Approvals
+
 This contract uses `tx.origin` for approvals to ensure only the user that deposited the funds can withdraw.
-This is limiting to only EOAs and not smart contracts. Ideally the contract would use `msg.sender` for approvals and 
+This is limiting to only EOAs and not smart contracts. Ideally the contract would use `msg.sender` for approvals and
 allow smart contracts to interface with the contract.
 
 ### No Owner for the Contract
-The contract does not implement OpenZeppelin's `Ownable` contract. This can cause issues as anybody can 
+
+The contract does not implement OpenZeppelin's `Ownable` contract. This can cause issues as anybody can
 execute the `pickWinner` function. Ideally some functions should be restricted to the owner of the contract
-like the `pickWinner` function which should be triggered off-chain a couple of seconds after the 
+like the `pickWinner` function which should be triggered off-chain a couple of seconds after the
 delegation rewards have been distributed
 
 ### No Multiple Validators
+
 The contract does not handle users delegating to multiple validators. This is for simplicity’s sake as this would require
 keeping track of which users have delegated to which validators and would require a more complex implementation.
 
 ### No Partial Exit Lottery
-The contract does not allow multiple undelegations with smaller amounts from the validator. 
-This is for simplicity’s sake as this would require keeping track of which users have undelegated how much 
+
+The contract does not allow multiple undelegations with smaller amounts from the validator.
+This is for simplicity’s sake as this would require keeping track of which users have undelegated how much
 and would require a more complex implementation.

--- a/examples/no-loss-lottery/contracts/NoLossLottery.sol
+++ b/examples/no-loss-lottery/contracts/NoLossLottery.sol
@@ -67,7 +67,8 @@ contract NoLossLottery {
         // Make sure that the sender has balance in our deposits map
         require(deposits[msg.sender] >= _amount, "Deposit amount larger than requested withdraw");
         // Transfer the requested amount of Evmos to the sender.
-        payable(msg.sender).transfer(_amount);
+        (bool sent,) = payable(msg.sender).call{value: _amount}("");
+        require(sent, "Failed to send Evmos");
         delete unbondingDelegations[msg.sender];
         emit Withdraw(msg.sender, _amount);
     }
@@ -75,7 +76,7 @@ contract NoLossLottery {
     // Withdraw winnings from contract
     function withdrawWinnings() public {
         require(winnings[msg.sender] > 0, "You have no winnings yet");
-        payable(msg.sender).transfer(winnings[msg.sender]);
+        (bool sent,) = payable(msg.sender).call{value: winnings[msg.sender]}("");
         winnings[msg.sender] = 0;
         emit WithdrawWinnings(msg.sender, winnings[msg.sender]);
     }

--- a/examples/no-loss-lottery/contracts/NoLossLottery.sol
+++ b/examples/no-loss-lottery/contracts/NoLossLottery.sol
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: LGPL-v3
+pragma solidity >=0.8.18;
+
+import "../../../precompiles/stateful/Staking.sol";
+import "../../../precompiles/stateful/Distribution.sol";
+
+contract NoLossLottery {
+
+    /// @dev A struct that keeps track of the winners for each round.
+    struct Winner {
+        uint16 round;
+        uint256 winningNumber;
+        address winnerAddress;
+        uint256 winingAmount;
+        uint256 timestamp;
+    }
+
+    /// @dev A struct that keeps track of the unbonding delegations.
+    struct UnbondingRequest {
+        int64 completionTime;
+        uint256 amount;
+    }
+
+    /// @dev the required authorizations for Staking and Distribution
+    string[] private stakingMethods = [MSG_DELEGATE, MSG_UNDELEGATE, MSG_REDELEGATE];
+    string[] private distributionMethods = [MSG_WITHDRAW_DELEGATOR_REWARD];
+    /// @dev map to keep track of user deposits to the contract.
+    mapping(address => uint256) public deposits;
+    /// @dev map to keep track of the delegation amounts for a user.
+    mapping(address => uint256) public delegations;
+    /// @dev map that keeps track of winnings
+    mapping(address => uint256) public winnings;
+    /// @dev map that keeps track of all currently unbonding delegations
+    mapping(address => UnbondingRequest) public unbondingDelegations;
+    /// @dev the total amount staked.
+    uint256 public totalStaked;
+    /// @dev the totalStaked amount converted to total number of tickets.
+    uint256 public totalTickets;
+    /// @dev array of addresses for each user that has entered the lottery.
+    address[] public participants;
+    /// @dev map to keep track of addresses that have entered the lottery.
+    mapping(address => bool) private addressExists;
+    /// @dev the winners array stores all historical winners.
+    Winner[] public winners;
+
+    /// @dev events emitted by the contract.
+    event Deposit(address indexed _from, uint256 _value);
+    event Withdraw(address indexed _to, uint256 _value);
+    event WithdrawWinnings(address indexed _to, uint256 _value);
+    event EnterLottery(address indexed _from, uint256 _value);
+    event ExitLottery(address indexed _to, uint256 _value);
+    event PickWinner(address indexed _winner, uint256 _value);
+
+    // Deposit into the contract
+    function deposit() payable external {
+        require(msg.value % 1 ether == 0, "Amount must be a whole number of Evmos");
+        deposits[msg.sender] += msg.value;
+        emit Deposit(msg.sender, msg.value);
+    }
+
+    // Withdraw deposits from contract
+    function withdraw(uint256 _amount) public {
+        uint256 ts = uint256(int256(unbondingDelegations[msg.sender].completionTime));
+        require(block.timestamp >= ts, "The time has not passed yet");
+        require(unbondingDelegations[msg.sender].amount > 0, "You have nothing to withdraw");
+        deposits[msg.sender] += unbondingDelegations[msg.sender].amount;
+        // Make sure that the sender has balance in our deposits map
+        require(deposits[msg.sender] >= _amount, "Deposit amount larger than requested withdraw");
+        // Transfer the requested amount of Evmos to the sender.
+        payable(msg.sender).transfer(_amount);
+        delete unbondingDelegations[msg.sender];
+        emit Withdraw(msg.sender, _amount);
+    }
+
+    // Withdraw winnings from contract
+    function withdrawWinnings() public {
+        require(winnings[msg.sender] > 0, "You have no winnings yet");
+        payable(msg.sender).transfer(winnings[msg.sender]);
+        winnings[msg.sender] = 0;
+        emit WithdrawWinnings(msg.sender, winnings[msg.sender]);
+    }
+
+    // Picks a winner for the lottery
+    function pickWinner(string memory _validatorAddr) public {
+        Coin[] memory newRewards = DISTRIBUTION_CONTRACT.withdrawDelegatorRewards(address(this), _validatorAddr);
+        require(newRewards[0].amount > 0, "The rewards have not been distributed yet");
+
+        // Used to ensure that the order of the participants array is not used to determine the winner.
+        _shuffleParticipants();
+
+        uint256 winnerIndex = getRandomNumber();
+        uint256 currentSum = 0;
+        address winner;
+
+        for (uint256 i = 0; i < participants.length; i++) {
+            currentSum += delegations[participants[i]] / 1e18;
+            if (currentSum >= winnerIndex) {
+                winner = participants[i];
+                break;
+            }
+        }
+
+        uint256 amountWon = newRewards[0].amount;
+        winners.push(Winner(uint16(winners.length + 1), winnerIndex, winner, amountWon, block.timestamp));
+        winnings[winner] += amountWon;
+        emit PickWinner(winner, amountWon);
+    }
+
+    // Enters the lottery by delegating to a validator
+    function enterLottery(string memory _validatorAddr, uint256 _amount) public {
+        require(_amount % 1 ether == 0, "Amount must be a whole number of Evmos");
+        require(_amount <= deposits[msg.sender], "This address does not hold a deposit amount with the lottery");
+        _approveRequiredMsgs(_amount);
+        STAKING_CONTRACT.delegate(address(this), _validatorAddr, _amount);
+        delegations[msg.sender] += _amount;
+        deposits[msg.sender] -= _amount;
+        totalStaked += _amount;
+        totalTickets += _amount / 1e18;
+        /// make sure an address is pushed only once per prize period
+        if (!addressExists[msg.sender]) {
+            participants.push(msg.sender);
+            addressExists[msg.sender] = true;
+        }
+        emit EnterLottery(msg.sender, _amount);
+    }
+
+    // Exits the lottery returning the funds back to deposits after the unbonding period
+    function exitLottery(string memory _validatorAddr, uint256 _amount) public {
+        require(_amount <= delegations[msg.sender], "This address does not hold a delegation amount with the lottery");
+        require(_amount == delegations[msg.sender], "You must exit the entire delegation amount");
+        int64 completionTime = STAKING_CONTRACT.undelegate(address(this), _validatorAddr, _amount);
+        delegations[msg.sender] -= _amount;
+        unbondingDelegations[msg.sender] = UnbondingRequest(completionTime, _amount);
+        totalStaked -= _amount;
+        deposits[msg.sender] += _amount;
+        totalTickets -= _amount / 1e18;
+
+        if (delegations[msg.sender] == 0) {
+            for (uint256 i = 0; i < participants.length; i++) {
+                if (participants[i] == msg.sender) {
+                    participants[i] = participants[participants.length - 1];
+                    participants.pop();
+                    break;
+                }
+            }
+        }
+
+        emit ExitLottery(msg.sender, _amount);
+    }
+
+
+    // ------------------------------
+    // VIEW FUNCTIONS
+    // ------------------------------
+    function getNumberOfRounds() public view returns (uint256){
+        return winners.length;
+    }
+
+    function getRandomNumber() public view returns (uint256) {
+        uint256 randomNumber = uint256(keccak256(abi.encodePacked(block.timestamp, block.prevrandao, block.number))) % totalTickets;
+        return randomNumber;
+    }
+
+    function getContractRewards(string memory _validatorAddr) public view returns (DecCoin[] memory) {
+        return DISTRIBUTION_CONTRACT.delegationRewards(address(this), _validatorAddr);
+    }
+
+    function getDelegation(address _sender, string memory _valAddr) public view returns (uint256, Coin memory) {
+        return STAKING_CONTRACT.delegation(_sender, _valAddr);
+    }
+
+    function getUnbondingDelegation(string memory _validatorAddr) public view returns (UnbondingDelegationEntry[] memory) {
+        return STAKING_CONTRACT.unbondingDelegation(address(this), _validatorAddr);
+    }
+
+    function getBalance() public view returns (uint256) {
+        return address(this).balance;
+    }
+
+    function getCurrentParticipants() public view returns (address[] memory) {
+        return participants;
+    }
+
+    // ------------------------------
+    // HELPER FUNCTIONS
+    // ------------------------------
+
+    /// @dev returns a random number between 0 and the number of participants
+    function _random() private view returns (uint256) {
+        uint256 randomNumber = uint256(keccak256(abi.encodePacked(block.timestamp, block.prevrandao, block.number))) % participants.length;
+        return randomNumber;
+    }
+
+    /// @dev shuffles the participants array
+    function _shuffleParticipants() private {
+        for (uint256 i = participants.length - 1; i > 0; i--) {
+            uint256 j = _random() % (i + 1);
+            (participants[i], participants[j]) = (participants[j], participants[i]);
+        }
+    }
+
+    /// @dev approves the staking and distribution contracts to spend the lottery's funds
+    function _approveRequiredMsgs(uint256 _amount) internal {
+        bool successStk = STAKING_CONTRACT.approve(tx.origin, _amount, stakingMethods);
+        require(successStk, "Staking Approve failed");
+        bool successDist = DISTRIBUTION_CONTRACT.approve(tx.origin, distributionMethods);
+        require(successDist, "Distribution Approve failed");
+    }
+
+}


### PR DESCRIPTION
This PR adds a `NoLossLottery.sol` contract that implements a no-loss-lottery using the `Staking` and `Distribution` extension. 