### PR TITLE
fix: Add Distribution Authorization, update code samples and docs

### DIFF
--- a/examples/no-loss-lottery/README.md
+++ b/examples/no-loss-lottery/README.md
@@ -65,12 +65,6 @@ The contract does not use an oracle for its random number generator or `shuffleP
 This is fine for a showcase but be aware when deploying to testnet or mainnet you would need a verifiable
 source of randomness.
 
-### Usage of `tx.origin` for Approvals
-
-
-This contract uses `tx.origin` for approvals to ensure only the user that deposited the funds can withdraw.
-This is limiting to only EOAs and not smart contracts. Ideally the contract would use `msg.sender` for approvals and
-allow smart contracts to interface with the contract.
 
 ### No Owner for the Contract
 

--- a/examples/no-loss-lottery/contracts/NoLossLottery.sol
+++ b/examples/no-loss-lottery/contracts/NoLossLottery.sol
@@ -202,9 +202,10 @@ contract NoLossLottery {
 
     /// @dev approves the staking and distribution contracts to spend the lottery's funds
     function _approveRequiredMsgs(uint256 _amount) internal {
+        string[] memory allowedList = new string[](0); // Defaults to the tx.origin address
         bool successStk = STAKING_CONTRACT.approve(tx.origin, _amount, stakingMethods);
         require(successStk, "Staking Approve failed");
-        bool successDist = DISTRIBUTION_CONTRACT.approve(tx.origin, distributionMethods);
+        bool successDist = DISTRIBUTION_CONTRACT.approve(address(this), distributionMethods, allowedList);
         require(successDist, "Distribution Approve failed");
     }
 

--- a/examples/simple-staker/README.md
+++ b/examples/simple-staker/README.md
@@ -26,7 +26,8 @@ We have provided convenient constants - `MSG_DELEGATE`, `MSG_UNDELEGATE`,
 `MSG_REDELEGATE`, `MSG_CANCEL_UNDELEGATION`, `MSG_SET_WITHDRAWER_ADDRESS`,
 `MSG_WITHDRAW_DELEGATOR_REWARD`, `MSG_WITHDRAW_VALIDATOR_COMMISSION` - for easier use.
 
-This is done by calling the `approve` function and will create an authorization grant for the given Cosmos SDK message.
+This is done by calling the `approve` function and will create an authorization grant for the given Cosmos SDK message
+for the given spender address (this usually should be `address(this)` to approve the calling contract.
 
 Note that the `approve` method for the `Staking` precompiled is different
 than the `Distribution` precompiled.

--- a/examples/simple-staker/contracts/SimpleStaker.sol
+++ b/examples/simple-staker/contracts/SimpleStaker.sol
@@ -13,6 +13,8 @@ contract SimpleStaker {
     /// @dev This creates a Cosmos Authorization Grants for the given methods.
     /// @dev This emits an Approval event.
     function approveRequiredMethods() public {
+
+        string[] memory allowedList = new string[](0); // Defaults to tx.origin when empty
         bool success = STAKING_CONTRACT.approve(
             msg.sender,
             type(uint256).max,
@@ -20,8 +22,9 @@ contract SimpleStaker {
         );
         require(success, "Failed to approve delegate method");
         success = DISTRIBUTION_CONTRACT.approve(
-            msg.sender,
-            distributionMethods
+            address(this),
+            distributionMethods,
+            allowedList
         );
         require(success, "Failed to approve withdraw delegator rewards method");
     }

--- a/examples/staking-manager/README.md
+++ b/examples/staking-manager/README.md
@@ -14,7 +14,8 @@ the approval and execution of the staking transaction or to combine them into a 
 
 We have provided convenient constants - `MSG_DELEGATE`, `MSG_UNDELEGATE`, `MSG_REDELEGATE`, `MSG_CANCEL_UNDELEGATION` for easier use.
 
-This is done by calling the `approve` function and will create an authorization grant for the given Cosmos SDK message. 
+This is done by calling the `approve` function and will create an authorization grant for the given Cosmos SDK message
+for the given spender address (this usually should be `address(this)` to approve the calling contract.
 
 ## Allowances
 

--- a/precompiles/abi/distribution.json
+++ b/precompiles/abi/distribution.json
@@ -19,9 +19,40 @@
         "internalType": "string[]",
         "name": "methods",
         "type": "string[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "string[]",
+        "name": "allowedList",
+        "type": "string[]"
       }
     ],
     "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "string[]",
+        "name": "methods",
+        "type": "string[]"
+      }
+    ],
+    "name": "Revocation",
     "type": "event"
   },
   {
@@ -97,6 +128,11 @@
       {
         "internalType": "string[]",
         "name": "methods",
+        "type": "string[]"
+      },
+      {
+        "internalType": "string[]",
+        "name": "allowedList",
         "type": "string[]"
       }
     ],
@@ -258,6 +294,30 @@
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "string[]",
+        "name": "methods",
+        "type": "string[]"
+      }
+    ],
+    "name": "revoke",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "revoked",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -442,6 +502,38 @@
         "internalType": "uint64",
         "name": "endingHeight",
         "type": "uint64"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bytes",
+            "name": "key",
+            "type": "bytes"
+          },
+          {
+            "internalType": "uint64",
+            "name": "offset",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "limit",
+            "type": "uint64"
+          },
+          {
+            "internalType": "bool",
+            "name": "countTotal",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "reverse",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct PageRequest",
+        "name": "pageRequest",
+        "type": "tuple"
       }
     ],
     "name": "validatorSlashes",

--- a/precompiles/common/DistributionAuthorization.sol
+++ b/precompiles/common/DistributionAuthorization.sol
@@ -1,17 +1,19 @@
-// SPDX-License-Identifier: LGPL-v3
-pragma solidity >=0.8.17;
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.8.17 .0;
 
 /// @author Evmos Team
-/// @title Authorization Interface
+/// @title Distribution Authorization Interface
 /// @dev The interface through which solidity contracts will interact with smart contract approvals.
-interface GenericAuthorizationI {
-    /// @dev Approves a list of Cosmos or IBC transactions with a specific amount of tokens.
+interface DistributionAuthorizationI {
+    /// @dev Approves a list of Cosmos transactions with a specific allowed list of addresses.
     /// @param spender The address which will spend the funds.
     /// @param methods The message type URLs of the methods to approve.
+    /// @param allowedList The list of allowed addresses.
     /// @return approved Boolean value to indicate if the approval was successful.
     function approve(
         address spender,
-        string[] calldata methods
+        string[] calldata methods,
+        string[] calldata allowedList
     ) external returns (bool approved);
 
     /// @dev Revokes a list of Cosmos transactions.
@@ -32,7 +34,8 @@ interface GenericAuthorizationI {
     event Approval(
         address indexed owner,
         address indexed spender,
-        string[] methods
+        string[] methods,
+        string[] allowedList
     );
 
     /// @dev This event is emitted when an owner revokes a spender's allowance.

--- a/precompiles/stateful/Distribution.sol
+++ b/precompiles/stateful/Distribution.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-v3
 pragma solidity >=0.8.17 .0;
 
-import "../common/GenericAuthorization.sol" as genericAuth;
+import "../common/DistributionAuthorization.sol" as distributionAuth;
 import "../common/Types.sol";
 
 /// @dev The DistributionI contract's address.
@@ -35,7 +35,7 @@ struct DelegationDelegatorReward {
 /// @title Distribution Precompile Contract
 /// @dev The interface through which solidity contracts will interact with Distribution
 /// @custom:address 0x0000000000000000000000000000000000000801
-interface DistributionI is genericAuth.GenericAuthorizationI {
+interface DistributionI is distributionAuth.DistributionAuthorizationI {
     /// TRANSACTIONS
     /// @dev Change the address, that can withdraw the rewards of a delegator.
     /// Note that this address cannot be a module account.


### PR DESCRIPTION
This PR adds the new DistributionAuthorization that includes an `allowedList` of addresses. Updates to the relevant code + docs was also made to conform to this new authz type. 