### PR TITLE
Bug/ Fix return values

### DIFF
--- a/examples/staking-manager/contracts/StakingManager.sol
+++ b/examples/staking-manager/contracts/StakingManager.sol
@@ -35,8 +35,8 @@ contract StakingManager {
     /// @dev This emits an Delegate event.
     /// @param _validatorAddr The address of the validator.
     /// @param _amount The amount of tokens to stake in aevmos.
-    /// @return completionTime The completion time of the staking transaction.
-    function stakeTokens(string memory _validatorAddr, uint256 _amount) public returns (int64 completionTime) {
+    /// @return success Whether the call was successful or not.
+    function stakeTokens(string memory _validatorAddr, uint256 _amount) public returns (bool success) {
         return STAKING_CONTRACT.delegate(msg.sender, _validatorAddr, _amount);
     }
 
@@ -64,7 +64,8 @@ contract StakingManager {
     /// @param _validatorAddr The address of the validator.
     /// @param _amount The amount of tokens to cancel the unbonding delegation in aevmos.
     /// @param _creationHeight The creation height of the unbonding delegation.
-    function cancelUnbondingDelegation(string memory _validatorAddr, uint256 _amount, uint256 _creationHeight) public returns (int64 completionTime) {
+    /// @return success Whether the call was successful or not.
+    function cancelUnbondingDelegation(string memory _validatorAddr, uint256 _amount, uint256 _creationHeight) public returns (bool success) {
         return STAKING_CONTRACT.cancelUnbondingDelegation(msg.sender, _validatorAddr, _amount, _creationHeight);
     }
 


### PR DESCRIPTION
`StakingManager.sol` had a compilation error, because of wrong return types. 

The functions, [delegate](https://github.com/cosmos/evm/blob/d781e119de10b210801921014c2d2c2e13b51045/precompiles/staking/StakingI.sol#L176) and [cancelUnbondingDelegation](https://github.com/cosmos/evm/blob/d781e119de10b210801921014c2d2c2e13b51045/precompiles/staking/StakingI.sol#L218) return a bool instead of an int64. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Modified staking operations to provide a boolean success indicator rather than a time-based value, offering clearer feedback on transaction outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->